### PR TITLE
Add ECS task credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Wrapper recognizes these non-curl arguments:
 - `--region` - AWS region name, if can't be automatically detected from host or
   if not explicitly provided in `AWS_DEFAULT_REGION` environment variable
 - `--ec2-creds` - use attached to EC2 credentials (instance role)
+- `--ecs-creds` - use attached to ECS credentials (task role)
 
 ### Response format
 
@@ -307,9 +308,14 @@ including access key, secret key, session token and region.
 
 Just import from the shell as `source ec2-import-creds`.
 
-Or you can use `--ec2-creds` options of `aws-cli` to get the same effect, but
+Or you can use `--ec2-creds` option of `aws-curl` to get the same effect, but
 importing credentials once in beginning is faster than importing for every
 `aws-curl` invocation.
+
+## ECS attached role
+
+When your service runs as ECS task you can import the attached credentials
+using `source ecs-import-creds` or `--ecs-creds` option.
 
 ## Platforms
 

--- a/aws-curl
+++ b/aws-curl
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck disable=SC2155,SC2001
 
-VERSION="1.0.9"
+VERSION="1.0.10"
 
 DATE_CMD="date"
 SED_CMD="sed"
@@ -21,7 +21,7 @@ fi
 #   safe url string
 ##
 urlsafe() {
-    echo "$1" | sed \
+    echo "$1" | $SED_CMD \
         -e 's!\x09!%09!g' \
         -e 's!\x0A!%0A!g' \
         -e 's!\x0B!%0B!g' \
@@ -336,7 +336,7 @@ sigv4_authorization_header() {
 }
 
 ##
-# Extracts key value from pretty-printed JSON-like structure.
+# Extracts key value from JSON-like structure.
 # Arguments:
 #   $1 payload
 #   $2 key name
@@ -344,7 +344,7 @@ sigv4_authorization_header() {
 #   key value
 ##
 get_key_value() {
-    echo "$1" | grep "$2" | cut -d ':' -f 2 | cut -d '"' -f 2
+    echo "$1" | $SED_CMD -n -e "s/.*\"$2\": *\"\([^\"]*\)\".*/\1/p"
 }
 
 ##
@@ -355,7 +355,7 @@ get_key_value() {
 #   region without az suffix
 ##
 strip_az_suffix() {
-    echo "$1" | sed -e 's![a-z]$!!'
+    echo "$1" | $SED_CMD -e 's![a-z]$!!'
 }
 
 ##
@@ -371,6 +371,21 @@ ec2_import_creds() {
     if [ -n "$availability_zone" ]; then
         AWS_DEFAULT_REGION=$(strip_az_suffix "$availability_zone")
     fi
+
+    if [ -n "$credentials" ]; then
+        AWS_ACCESS_KEY_ID=$(get_key_value "$credentials" "AccessKeyId")
+        AWS_SECRET_ACCESS_KEY=$(get_key_value "$credentials" "SecretAccessKey")
+        AWS_SESSION_TOKEN=$(get_key_value "$credentials" "Token")
+    fi
+}
+
+##
+# Imports credentials attached to ECS task
+##
+ecs_import_creds() {
+    curl_opts="--silent --connect-timeout 1 --fail"
+    ecs_creds_url="http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+    credentials=$(curl $curl_opts "$ecs_creds_url")
 
     if [ -n "$credentials" ]; then
         AWS_ACCESS_KEY_ID=$(get_key_value "$credentials" "AccessKeyId")
@@ -405,6 +420,7 @@ CURL_VERBOSE=""
 AWS_REGION=""
 AWS_SERVICE=""
 EC2_CREDS="0"
+ECS_CREDS="0"
 
 # read command line arguments
 while [ "$#" != 0 ]; do
@@ -460,6 +476,10 @@ while [ "$#" != 0 ]; do
             shift
             EC2_CREDS="1"
             ;;
+        --ecs-creds )
+            shift
+            ECS_CREDS="1"
+            ;;
         --data-ascii | --data-raw | --data-urlencode )
             echo "Option $1 is not supported at this time."
             exit 1
@@ -498,6 +518,11 @@ fi
 # import attached ec2 credentials if enabled
 if [ "$EC2_CREDS" = 1 ]; then
     ec2_import_creds
+fi
+
+# import attached ecs credentials if enabled
+if [ "$ECS_CREDS" = 1 ]; then
+    ecs_import_creds
 fi
 
 # check mandatory environment variables

--- a/ec2-import-creds
+++ b/ec2-import-creds
@@ -6,7 +6,7 @@ credentials=$([ -n "$attached_role_name" ] && curl -m 1 -s "http://169.254.169.2
 availability_zone="$(curl -m 1 -s "http://169.254.169.254/latest/meta-data/placement/availability-zone")"
 
 get_key_value() {
-  echo "$1" | grep "$2" | cut -d ':' -f 2 | cut -d '"' -f 2
+  echo "$1" | sed -n -e "s/.*\"$2\": *\"\([^\"]*\)\".*/\1/p"
 }
 
 strip_az_suffix() {

--- a/ecs-import-creds
+++ b/ecs-import-creds
@@ -1,0 +1,14 @@
+#!/bin/sh
+# shellcheck disable=SC2155
+
+credentials=$(curl -m 1 -s "http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+
+get_key_value() {
+  echo "$1" | sed -n -e "s/.*\"$2\": *\"\([^\"]*\)\".*/\1/p"
+}
+
+if [ -n "$credentials" ]; then
+  export AWS_ACCESS_KEY_ID=$(get_key_value "$credentials" "AccessKeyId")
+  export AWS_SECRET_ACCESS_KEY=$(get_key_value "$credentials" "SecretAccessKey")
+  export AWS_SESSION_TOKEN=$(get_key_value "$credentials" "Token")
+fi


### PR DESCRIPTION
Hi, this PR adds support for ECS task role credentials (see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) with `--ecs-creds` option or `ecs-import-creds` helper.

I modified `get_key_value` function to use `sed` for improvised JSON parsing, because it couldn't handle non pretty-printed JSON responses. I tested the `sed` variant for all cases (compact, pretty-printed, with space after colon). If the value doesn't contain double quotes, than it will work well (this would break even the original grep+cut variant).

There are some other minor changes for consistency.

Thank you!